### PR TITLE
Add a timeout to bootstrap instead of waiting a fixed delay.

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"log"
+	"log/slog"
 	"os"
 	"strconv"
 	"time"
@@ -15,6 +16,8 @@ var BucketSize = 20 // must be larger than 0
 var NodesProxyDomain = "kademlianodes"
 var Alpha = 3 // degree of parallelism
 var RPCTimeout = 5 * time.Second
+var BootstrapTimeout = 10 * time.Second
+var Debug = true
 
 func init() {
 	log.Println("Initialize environment variables")
@@ -70,4 +73,7 @@ func init() {
 		}
 	}
 
+	if Debug {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+	}
 }

--- a/env/env.go
+++ b/env/env.go
@@ -17,7 +17,6 @@ var NodesProxyDomain = "kademlianodes"
 var Alpha = 3 // degree of parallelism
 var RPCTimeout = 5 * time.Second
 var BootstrapTimeout = 10 * time.Second
-var Debug = true
 
 func init() {
 	log.Println("Initialize environment variables")
@@ -28,6 +27,7 @@ func init() {
 	nodesProxyDomain := os.Getenv("NODES_PROXY_DOMAIN")
 	alpha := os.Getenv("ALPHA")
 	rpcTimeoutInSeconds := os.Getenv("RPC_TIMEOUT_IN_SECONDS")
+	_, debug := os.LookupEnv("debug")
 
 	if port != "" {
 		portInt, err := strconv.Atoi(port)
@@ -73,7 +73,7 @@ func init() {
 		}
 	}
 
-	if Debug {
+	if debug {
 		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -3,7 +3,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"time"
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -64,7 +64,7 @@ func (n *Node) Bootstrap(rootCtx context.Context) error {
 		if err != nil {
 			logger.Warn("Unable to ping any ip", slog.Any("err", err))
 			slog.Warn("Retrying bootstrap in 100 milis")
-			time.Sleep(100*time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 
@@ -109,7 +109,8 @@ func (n *Node) pingIPsAndGetContact(ctx context.Context, targetIPs []string) (*c
 }
 
 func removeAddress(ips []string, addressToRemove string) []string {
-	ipToRemove := addressToRemove[:len(addressToRemove)-6]
+	portLength := 5 + /* colon */ 1
+	ipToRemove := addressToRemove[:len(addressToRemove)-portLength]
 
 	for idx, ip := range ips {
 		if ip == ipToRemove {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -61,14 +61,13 @@ func (n *Node) Bootstrap(rootCtx context.Context) error {
 		logger.Debug("pinging")
 
 		recipient, err = n.pingIPsAndGetContact(ctx, ips)
-		if err != nil {
-			logger.Warn("Unable to ping any ip", slog.Any("err", err))
-			slog.Warn("Retrying bootstrap in 100 milis")
-			time.Sleep(100 * time.Millisecond)
-			continue
+		if err == nil {
+			break
 		}
 
-		break
+		logger.Warn("Unable to ping any ip", slog.Any("err", err))
+		slog.Warn("Retrying bootstrap in 100 milis")
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	cancel()

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
+	"time"
 
 	"d7024e_group04/env"
 	"d7024e_group04/internal/kademlia/contact"
@@ -35,38 +37,52 @@ func New(client network.ClientRPC, routingTable *routingtable.RoutingTable, stor
  3. it does an iterativeFindNode for n
  4. it refreshes all buckets further away than its closest neighbor, which will be in the occupied bucket with the lowest index.
 */
-func (n *Node) Bootstrap(ctx context.Context) error {
-	addresses, err := n.kNet.ResolveDNS(env.NodesProxyDomain)
-	if err != nil {
-		return err
-	}
+func (n *Node) Bootstrap(rootCtx context.Context) error {
+	var recipient *contact.Contact
 
-	ourIP := n.RoutingTable.Me().Address
-
-	for idx, address := range addresses {
-		if address == ourIP[:len(ourIP)-6] {
-			addresses = append(addresses[:idx], addresses[idx+1:]...)
-			break
+	logger := slog.Default().With("me", n.RoutingTable.Me().Address)
+	ctx, cancel := context.WithTimeout(rootCtx, env.BootstrapTimeout)
+	for {
+		if ctx.Err() != nil {
+			cancel() // Only to make the linter happy
+			return ctx.Err()
 		}
+
+		ips, err := n.kNet.ResolveDNS(env.NodesProxyDomain)
+		if err != nil {
+			logger.Warn("Unable to resolve DNS", slog.Any("domain", env.NodesProxyDomain))
+			continue
+		}
+
+		ourAddress := n.RoutingTable.Me().Address
+		ips = removeAddress(ips, ourAddress)
+
+		logger := logger.With(slog.Any("ips", ips))
+
+		logger.Debug("pinging")
+
+		recipient, err = n.pingIPsAndGetContact(ctx, ips)
+		if err != nil {
+			logger.Warn("Unable to ping any ip", slog.Any("err", err))
+			slog.Warn("Retrying bootstrap in 100 milis")
+			time.Sleep(100*time.Millisecond)
+			continue
+		}
+
+		break
 	}
 
-	log.Printf("addresses:%v\n", addresses)
+	cancel()
 
-	contact, err := n.pingIPsAndGetContact(ctx, addresses)
-	if err != nil {
-		return err
-	}
-
-	n.RoutingTable.AddContact(contact)
+	n.RoutingTable.AddContact(recipient)
 	// TODO: iterative search, should we update once for the list or for each node visited in findNode?
 	me := n.RoutingTable.Me()
-	closestContacts := n.findNode(ctx, me)
+	closestContacts := n.findNode(rootCtx, me)
 	for _, contact := range closestContacts {
 		n.RoutingTable.AddContact(contact)
 	}
 
-	log.Println("FOUND NODES")
-	log.Print(closestContacts)
+	logger.Debug("FOUND NODES", slog.Any("nodes", closestContacts))
 
 	return nil
 }
@@ -91,4 +107,18 @@ func (n *Node) pingIPsAndGetContact(ctx context.Context, targetIPs []string) (*c
 	}
 
 	return nil, fmt.Errorf("unable to ping any contacts")
+}
+
+func removeAddress(ips []string, addressToRemove string) []string {
+	ipToRemove := addressToRemove[:len(addressToRemove)-6]
+
+	for idx, ip := range ips {
+		if ip == ipToRemove {
+			// Remove the ip
+			ips = append(ips[:idx], ips[idx+1:]...)
+			break
+		}
+	}
+
+	return ips
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -43,7 +43,7 @@ func (n *Node) Bootstrap(rootCtx context.Context) error {
 	ctx, cancel := context.WithTimeout(rootCtx, env.BootstrapTimeout)
 	for {
 		if ctx.Err() != nil {
-			cancel() // Only to make the linter happy
+			defer cancel()
 			return ctx.Err()
 		}
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -50,6 +50,7 @@ func (n *Node) Bootstrap(rootCtx context.Context) error {
 		ips, err := n.kNet.ResolveDNS(env.NodesProxyDomain)
 		if err != nil {
 			logger.Warn("Unable to resolve DNS", slog.Any("domain", env.NodesProxyDomain))
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,13 @@ package main
 
 import (
 	"context"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
 	"d7024e_group04/api"
 	"d7024e_group04/cli"
 	"d7024e_group04/env"
@@ -14,13 +21,6 @@ import (
 	"d7024e_group04/internal/node"
 	"d7024e_group04/internal/server"
 	"d7024e_group04/internal/store"
-	"log"
-	"net"
-	"os"
-	"os/signal"
-	"strconv"
-	"syscall"
-	"time"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -53,7 +53,7 @@ func createOwnContact() (me *contact.Contact) {
 	}
 	ip, err := net.LookupIP(host)
 	if err != nil {
-		panic("bad ip")
+		log.Fatalf("Invalid IP: %v", ip)
 	}
 
 	ipWithPort := ip[0].String() + ":" + strconv.Itoa(env.Port)
@@ -88,12 +88,7 @@ func startCLI(errGroup *errgroup.Group, errCtx context.Context, cancelCtx contex
 }
 
 func startBootstrapping(errGroup *errgroup.Group, errCtx context.Context, node *node.Node) {
-	delayTime := 5 * time.Second
-
 	errGroup.Go(func() error {
-		log.Printf("STARTING BOOTSTRAP after delay of %v seconds", delayTime)
-		time.Sleep(delayTime)
-
 		err := node.Bootstrap(errCtx)
 		if err != nil {
 			log.Fatalf("BOOTSTRAP failed: %v\n", err)


### PR DESCRIPTION
Tested by changing to `replicas: 1` in `docker-compose.yml`.

PD: also experimenting with [slog](https://pkg.go.dev/golang.org/x/exp/slog), the default structured logging solution provided by golang.

closes #42 