### PR TITLE
increase bootstrap timeout, fix findNodes adding bad nodes

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -16,7 +16,7 @@ var BucketSize = 20 // must be larger than 0
 var NodesProxyDomain = "kademlianodes"
 var Alpha = 3 // degree of parallelism
 var RPCTimeout = 5 * time.Second
-var BootstrapTimeout = 10 * time.Second
+var BootstrapTimeout = 1 * time.Minute
 
 func init() {
 	log.Println("Initialize environment variables")

--- a/internal/kademlia/contact/set.go
+++ b/internal/kademlia/contact/set.go
@@ -1,16 +1,19 @@
 package contact
 
-import "sync"
+import (
+	"d7024e_group04/internal/kademlia/kademliaid"
+	"sync"
+)
 
 // A mathematical set of contacts with a mutex for thread safety
 type ContactSet struct {
-	m map[*Contact]bool
+	m map[kademliaid.KademliaID]bool
 	sync.RWMutex
 }
 
 func NewContactSet() *ContactSet {
 	return &ContactSet{
-		m: make(map[*Contact]bool),
+		m: make(map[kademliaid.KademliaID]bool),
 	}
 }
 
@@ -18,7 +21,7 @@ func NewContactSet() *ContactSet {
 func (s *ContactSet) Add(item *Contact) {
 	s.Lock()
 	defer s.Unlock()
-	s.m[item] = true
+	s.m[item.ID] = true
 }
 
 // Add adds a slice of contacts to the set
@@ -26,7 +29,7 @@ func (s *ContactSet) Adds(items []*Contact) {
 	s.Lock()
 	defer s.Unlock()
 	for _, item := range items {
-		s.m[item] = true
+		s.m[item.ID] = true
 	}
 }
 
@@ -34,14 +37,14 @@ func (s *ContactSet) Adds(items []*Contact) {
 func (s *ContactSet) Remove(item *Contact) {
 	s.Lock()
 	defer s.Unlock()
-	delete(s.m, item)
+	delete(s.m, item.ID)
 }
 
 // Has looks for the existence of the contact
 func (s *ContactSet) Has(item *Contact) bool {
 	s.RLock()
 	defer s.RUnlock()
-	_, ok := s.m[item]
+	_, ok := s.m[item.ID]
 	return ok
 }
 
@@ -56,21 +59,10 @@ func (s *ContactSet) Len() int {
 func (s *ContactSet) Clear() {
 	s.Lock()
 	defer s.Unlock()
-	s.m = make(map[*Contact]bool)
+	s.m = make(map[kademliaid.KademliaID]bool)
 }
 
 // IsEmpty checks for emptiness
 func (s *ContactSet) IsEmpty() bool {
 	return s.Len() == 0
-}
-
-// ContactSet returns a slice of all items
-func (s *ContactSet) List() []*Contact {
-	s.RLock()
-	defer s.RUnlock()
-	list := make([]*Contact, 0)
-	for item := range s.m {
-		list = append(list, item)
-	}
-	return list
 }

--- a/internal/kademlia/contact/set_test.go
+++ b/internal/kademlia/contact/set_test.go
@@ -17,7 +17,7 @@ func TestSet_Add(t *testing.T) {
 		t.Fatalf("wrong number of items in set, found %v, expected 1", len(set.m))
 	}
 
-	_, found := set.m[contact]
+	_, found := set.m[contact.ID]
 
 	if !found {
 		t.Fatalf("contact is not in set")
@@ -38,7 +38,7 @@ func TestSet_Adds(t *testing.T) {
 	}
 
 	for _, contact := range contacts {
-		_, found := set.m[contact]
+		_, found := set.m[contact.ID]
 		if !found {
 			t.Fatalf("contact is not in set")
 		}
@@ -55,7 +55,7 @@ func TestSet_Remove(t *testing.T) {
 		t.Fatalf("invalid number of items in set, got %v, expected %v", len(set.m), len(contacts))
 	}
 
-	_, found := set.m[contacts[0]]
+	_, found := set.m[contacts[0].ID]
 
 	if !found {
 		t.Fatalf("contact is not in set")
@@ -63,7 +63,7 @@ func TestSet_Remove(t *testing.T) {
 
 	set.Remove(contacts[0])
 
-	_, found = set.m[contacts[0]]
+	_, found = set.m[contacts[0].ID]
 
 	if found {
 		t.Fatalf("contact is still in set")
@@ -76,7 +76,7 @@ func TestSet_Has(t *testing.T) {
 
 	contacts := fillSet(set, 2)
 
-	_, found := set.m[contacts[0]]
+	_, found := set.m[contacts[0].ID]
 
 	if !found {
 		t.Fatalf("contact is not in set")
@@ -126,35 +126,11 @@ func TestSet_IsEmpty(t *testing.T) {
 	}
 }
 
-func TestSet_List(t *testing.T) {
-	set := NewContactSet()
-
-	contacts := fillSet(set, 3)
-
-	setContacts := set.List()
-
-	for _, setContact := range setContacts {
-		found := false
-
-		for _, contact := range contacts {
-			if setContact == contact {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			t.Fatalf("mismatching list, expected %v, got %v", contacts, setContacts)
-		}
-	}
-
-}
-
 func fillSet(set *ContactSet, count int) (contacts []*Contact) {
 	for i := range count {
 		contact := NewContact(kademliaid.NewRandomKademliaID(), fmt.Sprintf("address %v", i))
 		contacts = append(contacts, contact)
-		set.m[contact] = true
+		set.m[contact.ID] = true
 	}
 	return
 }

--- a/internal/node/findNode.go
+++ b/internal/node/findNode.go
@@ -58,7 +58,12 @@ func (n *Node) findNodeIteration(
 
 	// loop through responses and add to kClosest
 	for contacts := range responseContactChannel {
-		kClosest.addContacts(contacts, contactWeAreSearchingFor)
+		for _, contact := range contacts {
+			// don't add nodes that are already visited
+			if !visitedSet.Has(contact) {
+				kClosest.addContact(contact, contactWeAreSearchingFor)
+			}
+		}
 	}
 }
 

--- a/internal/node/kClosestList.go
+++ b/internal/node/kClosestList.go
@@ -63,25 +63,23 @@ func (kClosestList *kClosestList) remove(target *contact.Contact) {
 	kClosestList.list = contactList
 }
 
-func (kClosestList *kClosestList) addContacts(contacts []*contact.Contact, referenceContact *contact.Contact) {
-	for _, contact := range contacts {
-		contact.CalcDistance(referenceContact.ID)
+func (kClosestList *kClosestList) addContact(contact *contact.Contact, referenceContact *contact.Contact) {
+	contact.CalcDistance(referenceContact.ID)
 
-		if kClosestList.Has(contact) {
-			continue
-		}
+	if kClosestList.Has(contact) {
+		return
+	}
 
-		if len(kClosestList.list) < k {
-			kClosestList.list = append(kClosestList.list, contact)
-			kClosestList.sort()
-			kClosestList.updated = true
-			continue
-		}
+	if len(kClosestList.list) < k {
+		kClosestList.list = append(kClosestList.list, contact)
+		kClosestList.sort()
+		kClosestList.updated = true
+		return
+	}
 
-		if contact.Less(kClosestList.list[k-1]) {
-			kClosestList.list[k-1] = contact
-			kClosestList.sort()
-			kClosestList.updated = true
-		}
+	if contact.Less(kClosestList.list[k-1]) {
+		kClosestList.list[k-1] = contact
+		kClosestList.sort()
+		kClosestList.updated = true
 	}
 }


### PR DESCRIPTION
Bootstrap timed out when running with 10 seconds, hence why it was failing. closes #61 

findNodes was re-adding bad nodes to kClosest if that node was found in another node

Changed ContactSet to store kademliaID
ContactSet stored contact pointers, which could have identical values as another contact pointer.
Eg.
```
pointer1 = {id1, addr1}
pointer2 = {id1, addr1}  // same values as pointer1
```

if pointer1 was added to the set, running `ContactSet.Has(pointer2)` would return **false** as the pointer is different even though the dereferenced values are the same. 